### PR TITLE
Fix startup script path detection

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,9 +8,10 @@ from sentence_transformers import SentenceTransformer
 import config
 import json
 from startup import create_startup
+import os
 
 if __name__ == "__main__":
-    create_startup()
+    create_startup(script_path=os.path.abspath(__file__))
 
 
 

--- a/startup.py
+++ b/startup.py
@@ -4,11 +4,11 @@ def create_startup(name="ClipMind", script_path=None):
     if script_path is None:
         script_path = os.path.abspath(__file__)
 
-    startup_foler = os.path.join(
+    startup_folder = os.path.join(
         os.getenv('APPDATA'), 'Microsoft\\Windows\\Start Menu\\Programs\\Startup'
     )
 
-    bat_path = os.path.join(startup_foler, f"{name}.bat")
+    bat_path = os.path.join(startup_folder, f"{name}.bat")
 
     if os.path.exists(bat_path):
         print("ClipMind AutoStart Already Enabled")


### PR DESCRIPTION
## Summary
- use main script path when creating startup entry
- correct typo in variable name `startup_folder`

## Testing
- `python -m py_compile main.py startup.py search_clipmind.py`

------
https://chatgpt.com/codex/tasks/task_e_684873838ef4832a9ca5bf9c4d7e8079